### PR TITLE
Garmin sdk in maven + add support for surface interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,26 +2,21 @@
 Java command-line application to convert Suunto SDE dive log files as [exported](https://www.suunto.com/en-us/Support/faq-articles/dm5/how-do-i-import--export-dive-logs-to-dm5/) from Suunto Dive Manager to [ANT](https://www.thisisant.com/) Flexible and Interoperable Data Transport (FIT) format for [import](https://connect.garmin.com/modern/import-data) into Garmin Connect. I wrote this application after switching from a Suunto D3 to a Garmin [Descent Mk2](https://www.garmin.com/en-US/p/633356/pn/010-02132-00) dive computer and wanted to view all of my old logs in one platform. Using it requires downloading the free Garmin [Flexible and Interoperable Data Transfer (FIT) SDK](https://developer.garmin.com/fit/overview/); it is not available through a Maven repository and is not open source so I can't redistribute it here.
 
 # Instructions
-These instructions are written for Windows and assume that you have a current Java Runtime Environment installed. Steps might be slightly different on other platforms.
-1. Download and install the Garmin [Flexible and Interoperable Data Transfer (FIT) SDK](https://developer.garmin.com/fit/overview/).
-2. Update the `CLASSPATH` environment variable to include `fit.jar` file from the SDK in the previous step. ![Environment_Variables](https://user-images.githubusercontent.com/6307271/208803154-8b6ce48b-a54f-4e7d-bfa0-8b91a27ee588.png)
-3. Launch Suunto Dive Manager.
-4. In the Logbook pane, select all of the dives that you want to convert.
-5. On the menu select File, Export... ![SDM_Export](https://user-images.githubusercontent.com/6307271/208802543-bf036a41-f08b-4b08-a1bb-66d536198147.png)
-6. Click the Browse button.
-7. In the Save As dialog box, select a destination directory.
-8. Click the Save button.
-9. Click the Export button.
-10. Launch Command Prompt.
-11. Run the converter using a command like this, specifying the export file created in the previous steps as the first argument and the output directory as the second argument: `C:\Users\nrado\git\SdeToFit\target>java.exe -cp %CLASSPATH%;SdeToFit-1.0-SNAPSHOT.jar com.github.nradov.sdetofit.SdeToFit C:\Users\nrado\OneDrive\Documents\Divelogs.SDE C:\Users\nrado\OneDrive\Documents`.
-12. Launch a web browser.
-13. Log in to Garmin Connect and navigate to the [Import Data](https://connect.garmin.com/modern/import-data) page.
-14. Drop or select the converted FIT files.
-15. Click the Import Data button.
+These instructions are written for Linux and assume that you have a current Java Runtime Environment installed. Steps might be slightly different on other platforms.
+1. Export Suunto dives to SDE: ![SDM_Export](https://user-images.githubusercontent.com/6307271/208802543-bf036a41-f08b-4b08-a1bb-66d536198147.png)
+2. Compile and create fat jar: ` mvn clean compile assembly:single`
+3. Run the converter using a command like this, specifying the export file created in the previous steps as the first argument and the output directory as the second argument: 
+```bash
+java -cp ./target/SdeToFit-1.0-SNAPSHOT-jar-with-dependencies.jar  com.github.nradov.sdetofit.SdeToFit  ./Divelogs.SDE  output/
+Converting dive log: "0.xml"
+Converting dive log: "1.xml"
+Converting dive log: "2.xml"
+Converting dive log: "3.xml"
+```
+4. Import the FIT files into Garmin Connect on web.
 
 # Limitations
 * No support for time zone offsets. All times are treated as being in the local time zone.
 * No support for tissue loading (decompression) or tank pressures (air integration).
 * No support for bookmarks (such as "Slow"). In theory those could probably be converted to FIT `event` messages, but Garmin Connect and Garmin Dive don't display those anyway so it seems pointless.
-* No calculation of surface intervals.
-* Only tested with dive logs recorded using the Suunto D3 and exported from SDM 3.1.0; may not work correctly for other dive computers or SDM versions.
+* Only tested with dive logs recorded using the Suunto Mosquito and exported from SDM 3.1.0; may not work correctly for other dive computers or SDM versions.

--- a/pom.xml
+++ b/pom.xml
@@ -21,24 +21,14 @@
 		<url>https://github.com/nradov/SdeToFit/issues</url>
 	</issueManagement>
 	<properties>
-		<maven.compiler.source>19</maven.compiler.source>
-		<maven.compiler.target>19</maven.compiler.target>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 
 	<build>
 		<sourceDirectory>src</sourceDirectory>
 		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-site-plugin</artifactId>
-				<version>3.7</version>
-			</plugin>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-project-info-reports-plugin</artifactId>
-				<version>2.9</version>
-			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
@@ -51,18 +41,29 @@
 					</archive>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
+				<configuration>
+					<archive>
+						<manifest>
+							<mainClass>com.github.nradov.sdetofit.SdeToFit</mainClass>
+						</manifest>
+					</archive>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 
 	<dependencies>
 		<dependency>
-			<!-- https://developer.garmin.com/fit/download/ -->
 			<groupId>com.garmin</groupId>
 			<artifactId>fit</artifactId>
-			<version>21.94.00</version>
-			<type>jar</type>
-			<scope>system</scope>
-			<systemPath>${env.USERPROFILE}\Downloads\FitSDKRelease_21.94.00\java\fit.jar</systemPath>
+			<version>21.141.0</version>
 		</dependency>
 	</dependencies>
 </project>

--- a/src/com/github/nradov/sdetofit/Dive.java
+++ b/src/com/github/nradov/sdetofit/Dive.java
@@ -39,6 +39,9 @@ public interface Dive extends Comparable<Dive> {
 
 	/** Get the dive log number. */
 	long getDiveNumber();
+
+    /** Get the surface interval time */
+    long getSurfaceTime();
 	
 	/** Get the average dive depth in meters. */
 	float getAvgDepth();

--- a/src/com/github/nradov/sdetofit/SdeToFit.java
+++ b/src/com/github/nradov/sdetofit/SdeToFit.java
@@ -131,6 +131,7 @@ public final class SdeToFit {
 		encode.write(lapMesg);
 
 		final var diveSummaryMesg1 = new DiveSummaryMesg();
+        diveSummaryMesg1.setSurfaceInterval(dive.getSurfaceTime());
 		diveSummaryMesg1.setTimestamp(dive.getStartTime());
 		diveSummaryMesg1.setAvgDepth(dive.getAvgDepth());
 		diveSummaryMesg1.setMaxDepth(dive.getMaxDepth());

--- a/src/com/github/nradov/sdetofit/suunto/SuuntoSml.java
+++ b/src/com/github/nradov/sdetofit/suunto/SuuntoSml.java
@@ -173,6 +173,11 @@ public class SuuntoSml implements Dive, DivesSource {
 		return diveNumber;
 	}
 
+    @Override
+    public long getSurfaceTime() {
+        throw new UnsupportedOperationException();
+    }
+
 	@Override
 	public NavigableSet<Dive> getDives() {
 		return new TreeSet<Dive>(Collections.singleton(this));

--- a/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
+++ b/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
@@ -50,6 +50,7 @@ public class SuuntoXml implements Dive, DivesSource {
 	private final long serialNumber;
 	private final byte waterTemperatureMaxDepth;
 	private final long diveNumber;
+    private final long surfaceTime;
 	private final float maxDepth, meanDepth;
 
 	private final Element suunto;
@@ -67,11 +68,6 @@ public class SuuntoXml implements Dive, DivesSource {
 		final Document doc = db.parse(is);
 		suunto = doc.getDocumentElement();
 		
-		if (!DOCUMENT_ELEMENT_NAME.equals(suunto.getLocalName())) {
-			throw new IllegalArgumentException(
-					"Document element name is " + suunto.getLocalName() + " instead of " + DOCUMENT_ELEMENT_NAME);
-		}
-
 		final int sampleCnt = Integer.valueOf(suunto.getElementsByTagName("SAMPLECNT").item(0).getTextContent());
 		final String date = suunto.getElementsByTagName("DATE").item(0).getTextContent();
 		final int dayOfMonth = Integer.valueOf(date.substring(0, 2));
@@ -102,7 +98,7 @@ public class SuuntoXml implements Dive, DivesSource {
 		// where the first number is the dive number
 		final var logTitle = suunto.getElementsByTagName("LOGTITLE").item(0).getTextContent();
 		this.diveNumber = Long.parseLong(logTitle.substring(0, logTitle.indexOf('.')));
-
+		this.surfaceTime = Integer.valueOf(suunto.getElementsByTagName("SURFACETIME").item(0).getTextContent());
 		this.productName = suunto.getElementsByTagName("DEVICEMODEL").item(0).getTextContent();
 		this.serialNumber = Long.valueOf(suunto.getElementsByTagName("WRISTOPID").item(0).getTextContent());
 		this.waterTemperatureMaxDepth = Byte
@@ -190,6 +186,11 @@ public class SuuntoXml implements Dive, DivesSource {
 	public long getDiveNumber() {
 		return diveNumber;
 	}
+
+    @Override
+    public long getSurfaceTime() {
+        return surfaceTime;
+    }
 
 	@Override
 	public NavigableSet<Dive> getDives() {


### PR DESCRIPTION
Just opening a pull request here in case it's useful to anyone, doesn't need to be merged in, I used the following code to convert my dives from my Mosquito.

## What 
1. I added the Garmin SDK import from Maven repository
2. Building as a fat jar.
3. Supports conversion of surface interval time too.

## Testing
* Tested with Suunto Mosquito SDE divelog on Linux.
```java
java -cp ./target/SdeToFit-1.0-SNAPSHOT-jar-with-dependencies.jar  com.github.nradov.sdetofit.SdeToFit  ./Divelogs.SDE  output/
Converting dive log: "0.xml"
Converting dive log: "1.xml"
Converting dive log: "2.xml"
Converting dive log: "3.xml"
```
* I had to remove the check for `DOCUMENT_ELEMENT_NAME` because the Mosquito doesn't log that. Hopefully this doesn't break for the D3 or other computers.