### PR TITLE
Handle temperature values as floats in DM5 files

### DIFF
--- a/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
+++ b/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
@@ -134,7 +134,7 @@ public class SuuntoXml implements Dive, DivesSource {
 			}
 
 			final float depth = Float.valueOf(sample.getElementsByTagName("DEPTH").item(0).getTextContent());
-			final byte temperature = sample.getElementsByTagName("TEMPERATURE").item(0).getTextContent() != "" ? Byte.valueOf(sample.getElementsByTagName("TEMPERATURE").item(0).getTextContent()) : (byte) 0;
+			final byte temperature = sample.getElementsByTagName("TEMPERATURE").item(0).getTextContent() != "" ? (byte) Math.round(Float.valueOf(sample.getElementsByTagName("TEMPERATURE").item(0).getTextContent())) : (byte) 0;
 			// for most samples the temperature seems to be 0
 			final byte adjustedTemperature = temperature == (byte) 0 ? waterTemperatureMaxDepth : temperature;
 			final var record = new Record(dateTime, depth, adjustedTemperature);


### PR DESCRIPTION
Within SDE files exported from DM5, the temperature values are, for some unknown reason, saved as floating point numbers. As an example, if the recorded temperature was 28°C, the value would be saved as 27.99999 which causes the SDE to FIT process to fail.

This PR changes the evaluation of the temperature value to allow a floating point number. I tested with 18 dives exported from DM5 without issue. I also manually changed some of the temperature float values in the DM5 to integers (so as to mimic DM3 exports) and it worked as expected.