### PR TITLE
fix surfaceTime null and sample out of diveSeconds

### DIFF
--- a/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
+++ b/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
@@ -98,7 +98,8 @@ public class SuuntoXml implements Dive, DivesSource {
 		// where the first number is the dive number
 		final var logTitle = suunto.getElementsByTagName("LOGTITLE").item(0).getTextContent();
 		this.diveNumber = Long.parseLong(logTitle.substring(0, logTitle.indexOf('.')));
-		this.surfaceTime = Integer.valueOf(suunto.getElementsByTagName("SURFACETIME").item(0).getTextContent());
+		String surfaceTime_string = suunto.getElementsByTagName("SURFACETIME").item(0).getTextContent() != "" ? suunto.getElementsByTagName("SURFACETIME").item(0).getTextContent() : "0";
+		this.surfaceTime = Integer.valueOf(surfaceTime_string);
 		this.productName = suunto.getElementsByTagName("DEVICEMODEL").item(0).getTextContent();
 		this.serialNumber = Long.valueOf(suunto.getElementsByTagName("WRISTOPID").item(0).getTextContent());
 		this.waterTemperatureMaxDepth = Byte

--- a/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
+++ b/src/com/github/nradov/sdetofit/suunto/SuuntoXml.java
@@ -123,7 +123,7 @@ public class SuuntoXml implements Dive, DivesSource {
 		final int sampleCount = Integer.valueOf(suunto.getElementsByTagName("SAMPLECNT").item(0).getTextContent());
 		final int sampleInterval = Integer
 				.valueOf(suunto.getElementsByTagName("SAMPLEINTERVAL").item(0).getTextContent());
-		final int diveSeconds = sampleCount * sampleInterval;
+		final int diveSeconds = (sampleCount + 1) * sampleInterval;
 		final NodeList samples = suunto.getElementsByTagName("SAMPLE");
 		final DateTime dateTime = new DateTime(start);
 


### PR DESCRIPTION
This PR fixed 2 issue when I transfer log.
Suunto device: Suunto D5
Suunto DM5 1.5.4.510

**First issue surfaceTime is an empty string in my log**, I have no idea what it happen, 
Almost a half of my 90 dives also empty of surfaceTime,
Therefore, I added a condition to check if surfaceTime is an empty string. 
If it is, I will default it to '0'; otherwise, I use the recorded value.

**Second issue is I had an error that sampleTime > (sampleCount * sampleInterval) in a few logs**,
In my scenario,
SAMPLECNT: 313, SAMPLEINTERVAL: 10 ==>  diveSeconds  = SAMPLECNT * SAMPLEINTERVAL = 3130
But I also had SAMPLETIME on 3131 and 3133.
I thought the logic for SAMPLECNT is to increment it only after the SAMPLEINTERVAL (10 seconds) has completed. Therefore, we need to increment SAMPLECNT one last time to cover the final samples that occurred within that last 10-second interval.

This PR is open for discussion,I welcome any feedback, 
as someone may have a better solution the issue that I met.